### PR TITLE
fix the Promise type definition

### DIFF
--- a/typings.d.ts
+++ b/typings.d.ts
@@ -1,19 +1,19 @@
 declare module 'idb-keyval' {
   interface IDBKeyVal<Key> {
     /** Add a new value or update an existing one */
-    set<Value>(key: Key, value: Value): PromiseLike<void>;
+    set<Value>(key: Key, value: Value): Promise<void>;
 
     /** Get a value by key */
-    get<Value>(key: Key): PromiseLike<Value>;
+    get<Value>(key: Key): Promise<Value>;
 
     /** Get all keys in the database */
-    keys(): PromiseLike<Key[]>;
+    keys(): Promise<Key[]>;
 
     /** Delete an entry in the database by key */
-    delete(key: Key): PromiseLike<void>;
+    delete(key: Key): Promise<void>;
 
     /** Delete all entries in the database */
-    clear(): PromiseLike<void>;
+    clear(): Promise<void>;
   }
 
   const idbKeyVal: IDBKeyVal<string>;


### PR DESCRIPTION
The .catch() was giving the error 'Property 'catch' does not exist on type 'PromiseLike<void>'.

Changing from PromiseLike to Promise solved the error. 