### PR TITLE
Use correct file size

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is a super-simple-small promise-based keyval store implemented with IndexedDB, largely based on [async-storage by Mozilla](https://github.com/mozilla-b2g/gaia/blob/master/shared/js/async_storage.js).
 
-[localForage](https://github.com/localForage/localForage) offers similar functionality, but supports older browsers with broken/absent IDB implementations. Because of that, it's 6k, whereas idb-keyval is less than 500 bytes. Pick whichever works best for you!
+[localForage](https://github.com/localForage/localForage) offers similar functionality, but supports older browsers with broken/absent IDB implementations. Because of that, it's 6k, whereas idb-keyval is less than 1.2k. Pick whichever works best for you!
 
 This is only a keyval store. If you need to do more complex things like iteration & indexing, check out [IDB on NPM](https://www.npmjs.com/package/idb) (a little heavier at 1.7k). The first example in its README is how to recreate this library. 
 


### PR DESCRIPTION
As far as I can tell, idb-keyval-min.js has never been anywhere near 500 bytes. The [first version](https://github.com/jakearchibald/idb-keyval/blob/8c19bf47154854cb00b20e3fe3e10692a2f76b2b/dist/idb-keyval-min.js) in history was 1.13KB; it's 1.12KB now.