### PR TITLE
Add CDN usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,12 @@ That's it!
 
 ## Installing
 
+### Via CDN 
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/idb-keyval@3/dist/idb-keyval-iife.min.js"></script>
+```
+
 ### Via npm + webpack/rollup
 
 ```sh


### PR DESCRIPTION
I added a [jsDelivr CDN link](https://www.jsdelivr.com/package/npm/idb-keyval) to your readme to make it easier to use. jsDelivr is the fastest opensource CDN available and built specifically for production usage.