### PR TITLE
Don't run compress-iife script twice

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "module": "./dist/idb-keyval.mjs",
     "types": "./dist/idb-keyval.d.ts",
     "scripts": {
-        "build": "del dist && rollup -c && npm run compress-iife && npm run compress-iife && npm run create-compat && npm run compress-amd",
+        "build": "del dist && rollup -c && npm run compress-iife && npm run create-compat && npm run compress-amd",
         "compress-iife": "uglifyjs --compress --mangle -o dist/idb-keyval-iife.min.js dist/idb-keyval-iife.js",
         "create-compat": "babel dist/idb-keyval-iife.js | uglifyjs --compress --mangle > dist/idb-keyval-iife-compat.min.js",
         "compress-amd": "uglifyjs --compress --mangle -o dist/idb-keyval-amd.min.js dist/idb-keyval-amd.js"


### PR DESCRIPTION
Removing redundant `npm run compress-iife` command from `build` script.