### PR TITLE
Close and (lazily) open DB on document freeze

### DIFF
--- a/idb-keyval.ts
+++ b/idb-keyval.ts
@@ -4,18 +4,6 @@ export class Store {
   private closed: boolean = false;
   private autoclose?: () => void;
 
-  close(): void {
-    if (this.autoclose) {
-      this.closed = true;
-      document.removeEventListener('freeze', this.autoclose);
-      const db = _dbwm.get(this);
-      _dbwm.delete(this);
-      if (db) {
-        db.onclose = null;
-        db.close();
-      }
-    }
-  }
   constructor(dbName = 'keyval-store', readonly storeName = 'keyval', autoclose = false) {
     this._dbp = new Promise((resolve, reject) => {
       const openreq = indexedDB.open(dbName, 1);
@@ -37,6 +25,20 @@ export class Store {
       });
     }
   }
+
+  close(): void {
+    if (this.autoclose) {
+      this.closed = true;
+      document.removeEventListener('freeze', this.autoclose);
+      const db = _dbwm.get(this);
+      _dbwm.delete(this);
+      if (db) {
+        db.onclose = null;
+        db.close();
+      }
+    }
+  }
+
   private get dbp(): typeof this._dbp {
     if (this.closed) {
       this._dbp = new Promise((resolve, reject) => {

--- a/idb-keyval.ts
+++ b/idb-keyval.ts
@@ -1,7 +1,7 @@
 const _dbwm = new WeakMap<Store, IDBDatabase>();
 export class Store {
   private _dbp: Promise<IDBDatabase>;
-  private closed: boolean = false;
+  private closed?: boolean;
   private autoclose?: () => void;
 
   constructor(dbName = 'keyval-store', readonly storeName = 'keyval', autoclose = false) {


### PR DESCRIPTION
Close and (lazily) open DB on document freeze

This patch attempts to automatically close the DB after the document emits the `freeze` event; and reopen it lazily after the document is `resume`d.

No `resume` events are registered, in order to enforce/ensure laziness.