### PR TITLE
Mark package as being side effect free for tools

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "main": "./dist/idb-keyval-cjs.js",
     "module": "./dist/idb-keyval.mjs",
     "types": "./dist/idb-keyval.d.ts",
+    "sideEffects": false,
     "scripts": {
         "build": "del dist && rollup -c && npm run compress-iife && npm run create-compat && npm run create-cjs-compat && npm run compress-amd",
         "compress-iife": "uglifyjs --compress --mangle -o dist/idb-keyval-iife.min.js dist/idb-keyval-iife.js",


### PR DESCRIPTION
Some tools use the `"sideEffects"` property in `package.json` as an indication that a package can be tree-shaken.

* Webpack: https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free
* Bundlephobia: "This package exports ES6 modules, but isn't marked side-effect free."
  https://bundlephobia.com/result?p=idb-keyval@3.2.0 (see image below)

![image](https://user-images.githubusercontent.com/8770194/79854120-40f9cf80-83c9-11ea-9c05-94579057c5c3.png)

It can be helpful to have this property to ensure tree-shaking works out of the box.