### PR TITLE
getMultiple([...keys]): Get multiple keys in a single transaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,18 @@ get('hello').then(val => console.log(val));
 
 If there is no 'hello' key, then `val` will be `undefined`.
 
+
+### getMultiple:
+
+```js
+import { getMultiple } from 'idb-keyval';
+
+// logs: "world"
+getMultiple(['hello1', 'hello2']).then(([val1, val2]) => console.log(val1, val2));
+```
+
+If there is no 'hello1' key, then `val1` will be `undefined`, and so on for each other key and value.
+
 ### keys:
 
 ```js

--- a/idb-keyval.ts
+++ b/idb-keyval.ts
@@ -38,6 +38,14 @@ export function get<Type>(key: IDBValidKey, store = getDefaultStore()): Promise<
   }).then(() => req.result);
 }
 
+export function getMultiple<Type>(keys: IDBValidKey[], store = getDefaultStore()): Promise<Type[]> {
+  let reqs: IDBRequest[]
+
+  return store._withIDBStore('readonly', store => {
+    reqs = keys.map(key => store.get(key))
+  }).then(() => reqs.map(req => req.result))
+}
+
 export function set(key: IDBValidKey, value: any, store = getDefaultStore()): Promise<void> {
   return store._withIDBStore('readwrite', store => {
     store.put(value, key);


### PR DESCRIPTION
Useful for data-intensive applications - opening thousands of transactions to get a bunch of keys is orders of magnitude slower.