### PR TITLE
Add conditional exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,10 @@
   "description": "A super-simple-small keyval store built on top of IndexedDB",
   "main": "./dist/cjs-compat/index.js",
   "module": "./dist/esm/index.js",
-  "exports": "./dist/esm/index.js",
+  "exports": {
+    "require": "./dist/cjs-compat/index.js",
+    "import": "./dist/esm/index.js"
+  },
   "types": "./dist/esm/index.d.ts",
   "sideEffects": false,
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "./dist/cjs-compat/index.js",
   "module": "./dist/esm/index.js",
   "exports": {
-    "require": "./dist/cjs-compat/index.js",
+    "require": "./dist/cjs/index.js",
     "import": "./dist/esm/index.js"
   },
   "types": "./dist/esm/index.d.ts",


### PR DESCRIPTION
Adding conditional exports will make possible to import this library in node projects of `type:commonjs` under node versions that support the `exports` field. 

This is important for isomorphic apps when code using idb will only run in the client/sw but it will still be imported server side, resulting in an error if the above conditions are met.