### PR TITLE
Export package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,11 @@
   "main": "./dist/cjs-compat/index.js",
   "module": "./dist/esm/index.js",
   "exports": {
-    "require": "./dist/cjs/index.js",
-    "import": "./dist/esm/index.js"
+    ".": {
+      "require": "./dist/cjs/index.js",
+      "import": "./dist/esm/index.js"
+    },
+    "./package.json": "./package.json"
   },
   "types": "./dist/esm/index.d.ts",
   "sideEffects": false,


### PR DESCRIPTION
Some bundlers/tools rely on package metadata being publicly available. Adding `package.json` to exports allows those tools to require it.

https://github.com/nodejs/node/issues/33460 has more details on the issue.