### PR TITLE
Add export for all base dist folders

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
       "require": "./dist/cjs/index.js",
       "import": "./dist/esm/index.js"
     },
+    "./dist/*": "./dist/*/index.js",
     "./package.json": "./package.json"
   },
   "types": "./dist/esm/index.d.ts",


### PR DESCRIPTION
Hello, this is a great project and thank you for so actively working to maintain it!

I ran across the need for this when I was working on a webpack 5 project that has an alias resolution pointing into cjs-compat. I wasn't able to access the cjs-compat file because exports was blocking it. 

Adding this line allows anyone to still have the ability to directly pull from your `/dist` children folders when needed.