### PR TITLE
package.json "type": "module"

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "5.1.3",
   "description": "A super-simple-small keyval store built on top of IndexedDB",
   "main": "./dist/cjs-compat/index.js",
+  "type": "module",
   "module": "./dist/esm/index.js",
   "exports": {
     ".": {


### PR DESCRIPTION
Had the following build error when using `idb-keyval` with `sveltekit` and `adapter-cloudflare-worker`.

```
(node:51281) Warning: To load an ES module, set "type": "module" in the package.json or use the .mjs extension.
(Use `node --trace-warnings ...` to show where the warning was created)
> Cannot use import statement outside a module
/Users/holdph/personal/song-kit/node_modules/idb-keyval/dist/esm/index.js:1
import safariFix from 'safari-14-idb-fix';
^^^^^^
```

I added `"type": "module",` to the `package.json` of `node_modules` for both `idb-keyval` and `safari-14-idb-fix` and that allows me to build locally.