### PR TITLE
Remove safari-14-idb-fix from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,8 +77,5 @@
   },
   "lint-staged": {
     "*.{js,css,md,ts,html}": "prettier --write"
-  },
-  "dependencies": {
-    "safari-14-idb-fix": "^3.0.0"
   }
 }


### PR DESCRIPTION
I think this was missed in https://github.com/jakearchibald/idb-keyval/commit/1c01e450b9c7e1a1c9dea0972c56e49c2f04e395

Thanks for the lib @jakearchibald! 😃