### PR TITLE
Improve error handling

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,8 +4,9 @@ export function promisifyRequest<T = undefined>(
   return new Promise<T>((resolve, reject) => {
     // @ts-ignore - file size hacks
     request.oncomplete = request.onsuccess = () => resolve(request.result);
+    request.onerror = (e) => reject((e.target as IDBRequest<T> | IDBTransaction).error);
     // @ts-ignore - file size hacks
-    request.onabort = request.onerror = () => reject(request.error);
+    request.onabort = () => reject(request.error);
   });
 }
 


### PR DESCRIPTION
idb-keyval reported IDBTransaction.error if a `set` operation failed.  However, based on my reading of the IndexedDB spec, and based on testing, IDBTransaction.error may not be set at the time the `error` event fires. This can be seen under the following scenarios:

- If IDBObjectStore.add fails because a key already exists
- If a quota is exceeded in Safari
- If the transaction is aborted immediately after an IndexedDB operation is requested

The `error` event's EventTarget should give the specific IDBRequest that failed, and that IDBRequest's error property should always be populated, so accessing `event.target` should fix this issue.

I tried using a similar approach for `abort` events, but it did not work; strangely, the abort event's target appears to be the IDBOpenRequest associated with the transaction, rather than the transaction itself, so it does not have a usable error property.

This PR also adds limited unit tests to cover this scenario. Aborting a transaction immediately after issuing a database request appears to be a good way to force an error.

Fixes #163