### PR TITLE
Fix three bugs: nested transaction in `entries()`, build cleanup, and…

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A super-simple-small keyval store built on top of IndexedDB",
   "main": "./dist/compat.cjs",
   "module": "./dist/compat.js",
-  "unpkg": "./dist/iife-compat.js",
+  "unpkg": "./dist/umd.js",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -32,7 +32,7 @@ function getBabelPlugin() {
 
 export default async function ({ watch }) {
   const devBuild = watch;
-  await deleteAsync('.ts-tmp', 'dist');
+  await deleteAsync(['.ts-tmp', 'dist']);
 
   if (devBuild)
     return {

--- a/src/index.ts
+++ b/src/index.ts
@@ -265,10 +265,8 @@ export function entries<KeyType extends IDBValidKey, ValueType = any>(
 
     const items: [KeyType, ValueType][] = [];
 
-    return customStore('readonly', (store) =>
-      eachCursor(store, (cursor) =>
-        items.push([cursor.key as KeyType, cursor.value]),
-      ).then(() => items),
-    );
+    return eachCursor(store, (cursor) =>
+      items.push([cursor.key as KeyType, cursor.value]),
+    ).then(() => items);
   });
 }


### PR DESCRIPTION
… unpkg path.

Caught a few things during a deep read of the codebase. Three small but real bugs, plus two things worth knowing about.

## Bugs fixed

### `entries()` fallback path was opening a second transaction for no reason

When `getAll` / `getAllKeys` aren't available, `entries()` calls `customStore()` a second time from inside the first `customStore()` callback. That opens an entirely new read transaction instead of just reusing the one we already have open. `keys()` and `values()` don't do this - they just use the `store` reference they already got. It worked (two simultaneous read transactions is fine in IndexedDB), but it's wasteful and inconsistent. Fixed it to match the other two.

### `rollup.config.js` wasn't cleaning `dist/`

The clean step on build is `deleteAsync('.ts-tmp', 'dist')`. Looks like it should delete both `.ts-tmp` and `dist`, but `deleteAsync` takes an array of patterns as the first argument - a second positional argument is treated as options. So `'dist'` was being passed as a config object and silently ignored. Only `.ts-tmp` was ever deleted. Changed it to `deleteAsync(['.ts-tmp', 'dist'])`.

### `package.json` unpkg field pointed to a file that doesn't exist

`"unpkg": "./dist/iife-compat.js"` - but nothing in the build pipeline produces `iife-compat.js`. The UMD bundle is `dist/umd.js`. Since that's the actual file that gets shipped for CDN use, I pointed unpkg there instead.

## Things I noticed but didn't touch

- **Husky config is stale.** The `package.json` has hooks in the old v4 format, but the installed version is Husky v9, which uses `.husky/` directory hooks instead. The pre-commit hook doesn't run. Easy to fix if someone uses husky - trivial to migrate.

- **`missing-types.d.ts` is unused.** It augments `IDBObjectStore` with `openKeyCursor`, but nothing in the library calls it. Might have been needed with older TS DOM libs. Not harmful, just dead weight.

No breaking changes. The `entries()` fix is the most impactful - it removes a redundant transaction open on the cursor fallback path. The other two are build/config correctness.