### PR TITLE
fix: update() hanging on bad key, remove dead type file

### DIFF
--- a/missing-types.d.ts
+++ b/missing-types.d.ts
@@ -1,6 +1,0 @@
-interface IDBObjectStore {
-  openKeyCursor(
-    range?: IDBKeyRange | IDBValidKey,
-    direction?: IDBCursorDirection,
-  ): IDBRequest;
-}

--- a/src/index.ts
+++ b/src/index.ts
@@ -131,7 +131,8 @@ export function update<T = any>(
       // If I try to chain promises, the transaction closes in browsers
       // that use a promise polyfill (IE10/11).
       new Promise((resolve, reject) => {
-        store.get(key).onsuccess = function () {
+        const req = store.get(key);
+        req.onsuccess = function () {
           try {
             store.put(updater(this.result), key);
             resolve(promisifyRequest(store.transaction));
@@ -139,6 +140,7 @@ export function update<T = any>(
             reject(err);
           }
         };
+        req.onerror = () => reject(req.error);
       }),
   );
 }


### PR DESCRIPTION
Noticed update() was missing error handling on the store.get() call, if you passed a bad key the promise would just hang forever, unlike every other method in the lib. Added req.onerror to reject properly.

Also spotted missing-types.d.ts sitting there declaring openKeyCursor which isnt used anywhere and has been in the standard TS DOM lib for years. Cleaned it out.