### PR TITLE
fix: Type inconsistencies in delMany and getMany

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -106,7 +106,7 @@ export function setMany(
 export function getMany<T = any>(
   keys: IDBValidKey[],
   customStore = defaultGetStore(),
-): Promise<T[]> {
+): Promise<(T | undefined)[]> {
   return customStore('readonly', (store) =>
     Promise.all(keys.map((key) => promisifyRequest(store.get(key)))),
   );

--- a/src/index.ts
+++ b/src/index.ts
@@ -171,8 +171,8 @@ export function delMany(
   keys: IDBValidKey[],
   customStore = defaultGetStore(),
 ): Promise<void> {
-  return customStore('readwrite', (store: IDBObjectStore) => {
-    keys.forEach((key: IDBValidKey) => store.delete(key));
+  return customStore('readwrite', (store) => {
+    keys.forEach((key) => store.delete(key));
     return promisifyRequest(store.transaction);
   });
 }

--- a/test/index.ts
+++ b/test/index.ts
@@ -427,7 +427,7 @@ mocha.setup('tdd');
       }
       {
         const result = await getMany<number>([1, 2, 3]);
-        typeAssert<IsExact<typeof result, number[]>>(true);
+        typeAssert<IsExact<typeof result, (number | undefined)[]>>(true);
       }
     });
   });


### PR DESCRIPTION
Two quick type fixes:

- delMany had redundant store: IDBObjectStore / key: IDBValidKey annotations while every sibling function (set, setMany, del, clear) leaves them inferred. Removed for consistency, no behavior change.

- getMany claimed Promise<T[]> but missing keys produce undefined in the array at runtime. Changed to (T | undefined)[] to match get's T | undefined. Updated the test assertion to match.