### PR TITLE
fix: resolve documentation error, husky configuration, and database connection reliability issues

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+npx lint-staged

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ If you're targeting IE10/11, use the compat version, and import a `Promise` poly
 ```js
 // Import a Promise polyfill
 import 'es6-promise/auto';
-import { get, set } from 'idb-keyval/dist/esm-compat';
+import { get, set } from 'idb-keyval/dist/compat.js';
 ```
 
 ### All bundles

--- a/package.json
+++ b/package.json
@@ -72,11 +72,6 @@
     "tslib": "^2.8.1",
     "typescript": "^5.8.3"
   },
-  "husky": {
-    "hooks": {
-      "pre-commit": "lint-staged"
-    }
-  },
   "lint-staged": {
     "*.{js,css,md,ts,html}": "prettier --write"
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,9 @@ export function createStore(dbName: string, storeName: string): UseStore {
         // It's supposed to fire this event when that happens. Let's hope it does!
         db.onclose = () => (dbp = undefined);
       },
-      () => {},
+      () => {
+        dbp = undefined;
+      },
     );
     return dbp;
   };
@@ -134,7 +136,7 @@ export function update<T = any>(
         const req = store.get(key);
         req.onsuccess = function () {
           try {
-            store.put(updater(this.result), key);
+            store.put(updater(req.result), key);
             resolve(promisifyRequest(store.transaction));
           } catch (err) {
             reject(err);


### PR DESCRIPTION
Changes:

Fix the README compat import path. The v6 release moved build files but the
README was not updated. Users targeting IE10/11 were directed to import from
idb keyval dist esm compat which does not resolve. The fix points to the
correct path idb keyval dist compat.js.

Remove dead husky configuration. The package.json contained a husky hooks
block using a format incompatible with husky v9 which is the installed
version. The configuration was completely inert. The block is removed and a
.husky/pre commit file is provided in the correct v9 format.

Reset the database promise on connection failure. The createStore function
cached the IndexedDB open promise. If opening the database failed the
rejected promise was cached permanently with a silent empty error handler.
All subsequent operations would fail without recovery. The fix clears the
cached promise on rejection so the next operation retries the connection.

Replace this dot result with req dot result in the update function. The
event handler used the this keyword to access the request result which is
fragile and depends on correct DOM event dispatch binding. Using the closure
variable req directly is more robust and one character shorter.

No public API changes. All existing tests pass. TypeScript compilation is
clean.